### PR TITLE
Use newer Toit.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         # The versions should contain (at least) the lowest requirement
         #    and a version that is more up to date.
-        toit-version: [ v2.0.0-alpha.94, latest ]
+        toit-version: [ v2.0.0-alpha.150, latest ]
         include:
-          - toit-version: v2.0.0-alpha.94
+          - toit-version: v2.0.0-alpha.150
             version-name: old
           - toit-version: latest
             version-name: new


### PR DESCRIPTION
Only newer toit SDK releases have the "toit" executable.